### PR TITLE
fix: init logger in vhs publish flow

### DIFF
--- a/publish.go
+++ b/publish.go
@@ -29,6 +29,8 @@ var publishCmd = &cobra.Command{
 	SilenceUsage:  true,
 	SilenceErrors: true, // we print our own errors
 	RunE: func(cmd *cobra.Command, args []string) error {
+		InitLogger(logLevel)
+
 		url, err := Publish(cmd.Context(), args[0])
 		if err != nil {
 			return err


### PR DESCRIPTION
Was getting a nil pointer error before when calling `vhs publish` due to logger not being initialized. Fixed that, now `vhs publish seems to be working as expected`